### PR TITLE
feat(AuthAPI): useFetchの代替

### DIFF
--- a/srcs/app/composables/useApiFetch.ts
+++ b/srcs/app/composables/useApiFetch.ts
@@ -1,0 +1,32 @@
+import type { UseFetchOptions } from "nuxt/app";
+
+export const useApiFetch = <T>(
+  url: string,
+  options: UseFetchOptions<T> = {}
+) => {
+  const authToken = useCookie("auth-token");
+  const {
+    public: { apiBase },
+  } = useRuntimeConfig();
+
+  const headers = new Headers((options.headers as HeadersInit) || {});
+  if (authToken.value) {
+    headers.set("Authorization", `Bearer ${authToken.value}`);
+  }
+  return useFetch(url, {
+    ...options,
+    baseURL: apiBase as string,
+    headers,
+
+    onResponseError({ response }) {
+      if (response.status === 401) {
+        authToken.value = null;
+        navigateTo("/login");
+        useToast().addToast({
+          message: "Session expired. Please log in again.",
+          type: "error",
+        });
+      }
+    },
+  });
+};

--- a/srcs/app/pages/test/use-api.vue
+++ b/srcs/app/pages/test/use-api.vue
@@ -1,0 +1,124 @@
+<script setup lang="ts">
+import { ref } from "vue";
+
+// Cookieの状態をリアクティブに監視
+const authToken = useCookie("auth-token");
+
+// APIからのレスポンスを格納するRef
+const publicData = ref();
+const publicError = ref(null);
+const protectedData = ref(null);
+const protectedError = ref(null);
+const echoedHeaders = ref(null);
+
+// 「ログイン」処理（テスト用のトークンをCookieにセット）
+const login = () => {
+  authToken.value = "my-secret-token";
+};
+
+// 「ログアウト」処理（Cookieを削除）
+const logout = () => {
+  // 有効期限を過去にしてCookieを削除
+  authToken.value = null;
+  // 保護APIの結果もクリア
+  protectedData.value = null;
+  protectedError.value = null;
+};
+
+// 公開APIを叩く関数
+const fetchPublic = async () => {
+  publicData.value = null;
+  publicError.value = null;
+  const { data, error } = await useApiFetch("/test/public");
+  publicData.value = data.value;
+  publicError.value = error.value;
+};
+
+// 保護APIを叩く関数
+const fetchProtected = async () => {
+  protectedData.value = null;
+  protectedError.value = null;
+  const { data, error } = await useApiFetch("/test/private");
+  protectedData.value = data.value;
+  protectedError.value = error.value;
+};
+
+const fetchWithCustomHeaders = async () => {
+  echoedHeaders.value = null;
+  try {
+    // useApi$Fetchを使って、カスタムヘッダーを渡す
+    const japaneseMessage = "こんにちは！クライアントからのテストです。";
+    const data = await useApiFetch("/test/echo-header", {
+      headers: {
+        "X-Custom-Test-Header": encodeURIComponent(japaneseMessage),
+        "X-Another-Header": "12345",
+      },
+    });
+    echoedHeaders.value = data;
+  } catch (e) {
+    console.error(e);
+  }
+};
+</script>
+
+<template>
+  <div style="font-family: sans-serif; display: grid; gap: 2rem; padding: 2rem">
+    <h1>useApiFetch & Cookie テストページ</h1>
+
+    <section style="border: 1px solid #ccc; padding: 1rem">
+      <h2>1. Cookie操作</h2>
+      <p>
+        現在のトークン: <strong>{{ authToken || "なし" }}</strong>
+      </p>
+      <div style="display: flex; gap: 1rem">
+        <button @click="login">ログイン (トークン設定)</button>
+        <button @click="logout">ログアウト (トークン削除)</button>
+      </div>
+    </section>
+
+    <section style="border: 1px solid #ccc; padding: 1rem">
+      <h2>2. API実行</h2>
+      <div style="display: flex; gap: 1rem">
+        <button @click="fetchPublic">公開APIを叩く</button>
+        <button @click="fetchProtected">保護APIを叩く</button>
+        <button @click="fetchWithCustomHeaders">
+          カスタムヘッダーを送信して確認
+        </button>
+      </div>
+    </section>
+
+    <section style="border: 1px solid #ccc; padding: 1rem">
+      <h2>3. 結果表示</h2>
+      <div style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem">
+        <div>
+          <h3>公開APIの結果</h3>
+          <div v-if="publicError" style="color: red">
+            <p>エラーが発生しました:</p>
+            <pre>{{ publicError }}</pre>
+          </div>
+          <div v-else-if="publicData">
+            <pre>{{ publicData }}</pre>
+          </div>
+          <p v-else>未実行</p>
+        </div>
+        <div>
+          <h3>保護APIの結果</h3>
+          <div v-if="protectedError" style="color: red">
+            <p>エラーが発生しました:</p>
+            <pre>{{ protectedError }}</pre>
+          </div>
+          <div v-else-if="protectedData">
+            <pre>{{ protectedData }}</pre>
+          </div>
+          <p v-else>未実行</p>
+        </div>
+        <div>
+          <h3>ヘッダー確認APIの結果</h3>
+          <div v-if="echoedHeaders">
+            <pre>{{ echoedHeaders }}</pre>
+          </div>
+        </div>
+      </div>
+    </section>
+  </div>
+</template>

--- a/srcs/nuxt.config.ts
+++ b/srcs/nuxt.config.ts
@@ -13,5 +13,11 @@ export default defineNuxtConfig({
     },
   },
 
+  runtimeConfig: {
+    public: {
+      apiBase: process.env.API_BASE || "http://localhost:3000/api",
+    },
+  },
+
   modules: ["@nuxtjs/tailwindcss"],
 });

--- a/srcs/server/api/test/echo-header.get.ts
+++ b/srcs/server/api/test/echo-header.get.ts
@@ -1,0 +1,37 @@
+export default defineEventHandler((event) => {
+  // リクエストヘッダーをすべて取得
+  const headers = getRequestHeaders(event);
+
+  // 'x-custom-test-header'の値を取り出す
+  const encodedMessage = headers["x-custom-test-header"];
+  const anotherHeader = headers["x-another-header"];
+
+  // ヘッダーが存在するかチェック
+  if (!encodedMessage) {
+    return {
+      error: "x-custom-test-headerが見つかりません。",
+    };
+  }
+
+  // デコード処理
+  let decodedMessage = "";
+  try {
+    // decodeURIComponentで元の日本語に戻す
+    decodedMessage = decodeURIComponent(encodedMessage);
+  } catch (e) {
+    console.error("デコードに失敗しました:", e);
+    return {
+      error: "ヘッダーのデコードに失敗しました。",
+    };
+  }
+
+  // デコードしたメッセージをコンソールに表示（サーバーのターミナルに表示される）
+  console.log("デコードされたメッセージ:", decodedMessage);
+
+  // クライアントにも返してみる
+  return {
+    originalHeaderValue: encodedMessage,
+    decodedMessage: decodedMessage,
+    anotherHeader: anotherHeader || null,
+  };
+});

--- a/srcs/server/api/test/private.get.ts
+++ b/srcs/server/api/test/private.get.ts
@@ -1,0 +1,32 @@
+// /api/me へのGETリクエストを処理
+export default defineEventHandler((event) => {
+  // リクエストヘッダーを取得
+  const headers = getRequestHeaders(event);
+
+  // Authorizationヘッダーを確認
+  const authHeader = headers.authorization;
+
+  // テスト用の正しいトークン
+  const validToken = 'Bearer my-secret-token';
+
+  // ヘッダーが存在し、内容が正しいかチェック
+  if (authHeader === validToken) {
+    // 認証成功
+    setResponseStatus(event, 200); // 成功ステータス
+    return {
+      user: {
+        id: 1,
+        name: 'テストユーザー',
+        email: 'test@example.com',
+      },
+    };
+  }
+
+  // 認証失敗
+  // 401エラーを投げる
+  throw createError({
+    statusCode: 401,
+    statusMessage: 'Unauthorized',
+    message: '認証トークンが無効です。',
+  });
+});

--- a/srcs/server/api/test/public.get.ts
+++ b/srcs/server/api/test/public.get.ts
@@ -1,0 +1,7 @@
+// /api/public へのGETリクエストを処理
+export default defineEventHandler(() => {
+  return {
+    message: 'これは誰でもアクセスできる公開データです。',
+    timestamp: new Date().toISOString(),
+  };
+});


### PR DESCRIPTION
<!-- I want to review in Japanese. -->
テスト用のページtest/use-api.vue
クッキーとか削除追加わからんかったので適当実装。一回一回ページ読み込まないといけないかも

<!-- for Github Copilot review rule -->

[必須]: セキュリティ、バグ、重大な設計問題
[推奨]: パフォーマンス改善、可読性向上
[提案]: より良い実装方法の提案
[質問]: 実装意図の確認
[Nits]: 細かな修正（typo、フォーマットなど）

関数と変数: camelCase
定数: UPPER_SNAKE_CASE

<!-- for Github Copilot review rule -->

<!-- I want to review in Japanese. -->
